### PR TITLE
[fix]未ログイン時の詳細画面

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,8 +7,10 @@
     <% end %>
     <div class="flex items-center justify-between">
       <div class="font-bold text-xl mb-2"><%= @post.title %></div>
-      <% unless current_user.own?(@post) %>
-        <%= render "posts/like_buttons", { post: @post } %>
+      <% if user_signed_in? %>
+        <% unless current_user.own?(@post) %>
+          <%= render "posts/like_buttons", { post: @post } %>
+        <% end %>
       <% end %>
     </div>
 
@@ -24,9 +26,11 @@
   </div>
 
   <div class="px-6 pt-4 pb-2 flex space-x-2">
-    <% if current_user.own?(@post) %>
-      <%= link_to "編集", edit_post_path(@post), class: "btn btn-sm btn-primary" %>
-      <%= link_to "削除", post_path(@post), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか?" }, class: "btn btn-sm btn-error text-white" %>
+    <% if user_signed_in? %>
+      <% if current_user.own?(@post) %>
+        <%= link_to "編集", edit_post_path(@post), class: "btn btn-sm btn-primary" %>
+        <%= link_to "削除", post_path(@post), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか?" }, class: "btn btn-sm btn-error text-white" %>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
エラー修正

## 内容
未ログイン時にみんなの投稿の詳細画面へアクセスするとエラー発生。

- 原因
未ログイン状態で投稿詳細ページにアクセスした際、
`current_user`がnilとなり`own?`を呼び出して 500 エラーが発生していた。

- 修正対応
`if user_signed_in?`を追加し、ログイン時のみ`current_user.own?(@post)` が判定できるようにした。